### PR TITLE
Fix print call so it works with newer versions of Python

### DIFF
--- a/modules/operating-system/main.tf
+++ b/modules/operating-system/main.tf
@@ -1,3 +1,3 @@
 data "external" "os" {
-  program = ["python", "-c", "import platform; print \"{\\\"platform\\\": \\\"%s\\\"}\" % platform.system()"]
+  program = ["python", "-c", "import platform; print(\"{\\\"platform\\\": \\\"%s\\\"}\" % platform.system())"]
 }


### PR DESCRIPTION
I guess in some Python version `print` went from a statement to a function.