### PR TITLE
Lock PIP's version to be smaller than 21.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
             # transitive dependencies that are being pulled in which released new versions that are no longer compatible
             # with any python < 3.6.
             pyenv global 3.5.2
-            pip3 install --upgrade pip
-            pip3 install pre-commit==1.21.0 cfgv==2.0.1 zipp==1.1.0
+            pip install --upgrade "pip < 21.0"
+            pip install pre-commit==1.21.0 cfgv==2.0.1 zipp==1.1.0
             pre-commit install
             pre-commit run --all-files
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
             # transitive dependencies that are being pulled in which released new versions that are no longer compatible
             # with any python < 3.6.
             pyenv global 3.5.2
-            pip install --upgrade pip
-            pip install pre-commit==1.21.0 cfgv==2.0.1 zipp==1.1.0
+            pip3 install --upgrade pip
+            pip3 install pre-commit==1.21.0 cfgv==2.0.1 zipp==1.1.0
             pre-commit install
             pre-commit run --all-files
       - run:


### PR DESCRIPTION
This will fix the current broken build. [The newer version of PIP doesn't support 2.7.](https://stackoverflow.com/a/65896996)