### PR TITLE
Update all repo names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           command: |
             sudo apt-get -y update
             curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
-            gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "${MODULE_CI_VERSION}"
+            gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
             gruntwork-install --binary-name "terratest_log_parser" --repo "https://github.com/gruntwork-io/terratest" --tag "${TERRATEST_LOG_PARSER_VERSION}"
             configure-environment-for-gruntwork-module \
               --go-src-path ./test \

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-package-terraform-utilities
+terraform-aws-utilities
 Copyright 2019 Gruntwork, Inc.
 
 This product includes software developed at Gruntwork (https://www.gruntwork.io/).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Maintained by Gruntwork.io](https://img.shields.io/badge/maintained%20by-gruntwork.io-%235849a6.svg)](https://gruntwork.io/?ref=repo_package_terraform_utilities)
-[![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/gruntwork-io/package-terraform-utilities.svg?label=latest)](https://github.com/gruntwork-io/package-terraform-utilities/releases/latest)
+[![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/gruntwork-io/terraform-aws-utilities.svg?label=latest)](https://github.com/gruntwork-io/terraform-aws-utilities/releases/latest)
 ![Terraform Version](https://img.shields.io/badge/tf-%3E%3D0.14.0-blue.svg)
 
 # Terraform Utility Modules

--- a/examples/executable-dependency/main.tf
+++ b/examples/executable-dependency/main.tf
@@ -8,7 +8,7 @@ terraform {
 module "executable" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/executable-dependency?ref=v1.0.8"
+  # source = "git::git@github.com:gruntwork-io/terraform-aws-utilities.git//modules/executable-dependency?ref=v1.0.8"
   source = "../../modules/executable-dependency"
 
   executable     = var.executable

--- a/examples/join-path/main.tf
+++ b/examples/join-path/main.tf
@@ -8,7 +8,7 @@ terraform {
 module "path" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/join-path?ref=v1.0.8"
+  # source = "git::git@github.com:gruntwork-io/terraform-aws-utilities.git//modules/join-path?ref=v1.0.8"
   source = "../../modules/join-path"
 
   path_parts = ["foo", "bar", "baz.txt"]

--- a/examples/list-remove/main.tf
+++ b/examples/list-remove/main.tf
@@ -8,7 +8,7 @@ terraform {
 module "list_remove" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/list-remove?ref=v0.0.8"
+  # source = "git::git@github.com:gruntwork-io/terraform-aws-utilities.git//modules/list-remove?ref=v0.0.8"
   source = "../../modules/list-remove"
 
   original_list   = var.input_list

--- a/examples/operating-system/main.tf
+++ b/examples/operating-system/main.tf
@@ -8,6 +8,6 @@ terraform {
 module "os" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/operating-system?ref=v1.0.8"
+  # source = "git::git@github.com:gruntwork-io/terraform-aws-utilities.git//modules/operating-system?ref=v1.0.8"
   source = "../../modules/operating-system"
 }

--- a/examples/pex/main.tf
+++ b/examples/pex/main.tf
@@ -15,7 +15,7 @@ terraform {
 module "pex_resource" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/run-pex-as-resource?ref=v1.0.8"
+  # source = "git::git@github.com:gruntwork-io/terraform-aws-utilities.git//modules/run-pex-as-resource?ref=v1.0.8"
   source = "../../modules/run-pex-as-resource"
 
   triggers = var.triggers
@@ -58,7 +58,7 @@ module "pex_resource" {
 module "pex_data" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/run-pex-as-data-source?ref=v1.0.8"
+  # source = "git::git@github.com:gruntwork-io/terraform-aws-utilities.git//modules/run-pex-as-data-source?ref=v1.0.8"
   source = "../../modules/run-pex-as-data-source"
 
   # Path components to each of the PEX binary

--- a/examples/require-executable/main.tf
+++ b/examples/require-executable/main.tf
@@ -8,7 +8,7 @@ terraform {
 module "require_executables" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/require-executable?ref=v1.0.8"
+  # source = "git::git@github.com:gruntwork-io/terraform-aws-utilities.git//modules/require-executable?ref=v1.0.8"
   source = "../../modules/require-executable"
 
   required_executables = var.required_executables
@@ -19,7 +19,7 @@ module "require_executables" {
 module "conditional_require_executables" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/require-executable?ref=v1.0.8"
+  # source = "git::git@github.com:gruntwork-io/terraform-aws-utilities.git//modules/require-executable?ref=v1.0.8"
   source = "../../modules/require-executable"
 
   required_executables = [var.validate_bad_executable ? "this-executable-should-not-exist" : ""]

--- a/modules/executable-dependency/README.md
+++ b/modules/executable-dependency/README.md
@@ -21,11 +21,11 @@ See the [executable-dependency example](/examples/executable-dependency) for wor
 ## Usage
 
 Use the module in your Terraform code, replacing `<VERSION>` with the latest version from the [releases
-page](https://github.com/gruntwork-io/package-terraform-utilities/releases):
+page](https://github.com/gruntwork-io/terraform-aws-utilities/releases):
 
 ```hcl
 module "path" {
-  source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/join-path?ref=<VERSION>"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-utilities.git//modules/join-path?ref=<VERSION>"
   
   executable     = "kubergrunt"
   download_url   = "https://github.com/gruntwork-io/kubergrunt/releases/download/v0.5.13/kubergrunt"

--- a/modules/instance-type/README.md
+++ b/modules/instance-type/README.md
@@ -20,11 +20,11 @@ See the [instance-type example](/examples/instance-type) for working sample code
 ## Usage
 
 Use the module in your Terraform code, replacing `<VERSION>` with the latest version from the [releases
-page](https://github.com/gruntwork-io/package-terraform-utilities/releases):
+page](https://github.com/gruntwork-io/terraform-aws-utilities/releases):
 
 ```hcl
 module "path" {
-  source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/instance-type?ref=<VERSION>"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-utilities.git//modules/instance-type?ref=<VERSION>"
   
   instance_types = ["t2.micro", "t3.micro"]
 }

--- a/modules/join-path/README.md
+++ b/modules/join-path/README.md
@@ -19,12 +19,12 @@ See the [join-path example](/examples/join-path) for working sample code.
 ## Usage
 
 Simply use the module in your Terraform code, replacing `<VERSION>` with the latest version from the [releases
-page](https://github.com/gruntwork-io/package-terraform-utilities/releases), and specifying the path parts using the 
+page](https://github.com/gruntwork-io/terraform-aws-utilities/releases), and specifying the path parts using the 
 `path_parts` input:
 
 ```hcl
 module "path" {
-  source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/join-path?ref=<VERSION>"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-utilities.git//modules/join-path?ref=<VERSION>"
   
   path_parts = ["foo", "bar", "baz.txt"]
 }

--- a/modules/list-remove/README.md
+++ b/modules/list-remove/README.md
@@ -9,7 +9,7 @@ For example, suppose you have a list of availability zones (`["us-east-1a", "us-
 
 ```hcl
 module "list_remove" {
-  source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/list-remove?ref=v0.0.8"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-utilities.git//modules/list-remove?ref=v0.0.8"
 
   original_list = ["us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d", "us-east-1e"]
   items_to_remove = ["us-east-1b", "us-east-1c"]

--- a/modules/operating-system/README.md
+++ b/modules/operating-system/README.md
@@ -19,11 +19,11 @@ See the [operating-system example](/examples/operating-system) for working sampl
 ## Usage
 
 Simply use the module in your Terraform code, replacing `<VERSION>` with the latest version from the [releases
-page](https://github.com/gruntwork-io/package-terraform-utilities/releases):
+page](https://github.com/gruntwork-io/terraform-aws-utilities/releases):
 
 ```hcl
 module "os" {
-  source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/operating-system?ref=<VERSION>"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-utilities.git//modules/operating-system?ref=<VERSION>"
 }
 ```
 

--- a/modules/request-quota-increase/README.md
+++ b/modules/request-quota-increase/README.md
@@ -22,11 +22,11 @@ See the [request-quota-increase example](/examples/request-quota-increase) for w
 ## Usage
 
 Use the module in your Terraform code, replacing `<VERSION>` with the latest version from the [releases
-page](https://github.com/gruntwork-io/package-terraform-utilities/releases):
+page](https://github.com/gruntwork-io/terraform-aws-utilities/releases):
 
 ```hcl
 module "path" {
-  source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/quota-increase?ref=<VERSION>"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-utilities.git//modules/quota-increase?ref=<VERSION>"
 
     request_quota_increase = {
       nat_gateway = 40,

--- a/modules/require-executable/README.md
+++ b/modules/require-executable/README.md
@@ -26,7 +26,7 @@ check if `go` is installed based on the condition `validate_go`. You can achieve
 
 ```hcl
 module "require_executables" {
-  source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/require-executable?ref=v1.0.8"
+  source = "git::git@github.com:gruntwork-io/terraform-aws-utilities.git//modules/require-executable?ref=v1.0.8"
   required_executables = ["${var.validate_go ? "go" : ""}"]
 }
 ```


### PR DESCRIPTION
_**This PR was created by git-xargs. See https://github.com/gruntwork-io/prototypes/pull/152 for context.**_ We recently renamed all of our repos to follow the Terraform registry format of  (e.g., ). This PR does a search & replace to update all references to these repos to the new names. GitHub can handle redirects, so in theory, everything should work fine with the old names, but there were so many renames, that to reduce confusion, this will update most of our references to the proper values.