### PR TITLE
[IAC-1677] Replace gofmt with goimports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,8 @@ jobs:
             pyenv global 3.5.2
             pip install --upgrade "pip < 21.0"
             pip install pre-commit==1.21.0 cfgv==2.0.1 zipp==1.1.0
+            go get golang.org/x/tools/cmd/goimports
+            export GOPATH=~/go/bin && export PATH=$PATH:$GOPATH 
             pre-commit install
             pre-commit run --all-files
       - run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev:  v0.1.10
     hooks:
       - id: terraform-fmt
-      - id: gofmt
+      - id: goimports

--- a/test/instance_type_test.go
+++ b/test/instance_type_test.go
@@ -1,9 +1,10 @@
 package test
 
 import (
+	"testing"
+
 	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	"testing"
 )
 
 func TestInstanceType(t *testing.T) {

--- a/test/join_path_test.go
+++ b/test/join_path_test.go
@@ -1,8 +1,9 @@
 package test
 
 import (
-	"github.com/gruntwork-io/terratest/modules/terraform"
 	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 func TestJoinPath(t *testing.T) {

--- a/test/list_remove_test.go
+++ b/test/list_remove_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 func TestListRemove(t *testing.T) {

--- a/test/operating_system_test.go
+++ b/test/operating_system_test.go
@@ -1,10 +1,11 @@
 package test
 
 import (
-	"github.com/gruntwork-io/terratest/modules/terraform"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 func TestOperatingSystem(t *testing.T) {

--- a/test/request_quota_increase_test.go
+++ b/test/request_quota_increase_test.go
@@ -1,10 +1,11 @@
 package test
 
 import (
+	"testing"
+
 	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 type (

--- a/test/require_executable_test.go
+++ b/test/require_executable_test.go
@@ -1,13 +1,14 @@
 package test
 
 import (
-	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
-	"github.com/stretchr/testify/assert"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRequireExecutableWorksWithExistingExecutable(t *testing.T) {


### PR DESCRIPTION
Replace gofmt with goimports in the pre-commit configuration. Note: This PR was opened using git-xargs.