### PR TITLE
Fix upgrade tests to use main as the base branch instead of master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
             run-go-tests \
               --path ./test/upgrades \
               --timeout 1h \
-              --extra-flags "-ldflags '-X github.com/gruntwork-io/terraform-aws-ci/test/upgrades.BaseRef=$UPGRADE_TEST_BASE_REF -X github.com/gruntwork-io/terraform-aws-ci/test/upgrades.TFBaseVersion=$UPGRADE_TEST_TF_BASE_VERSION -X github.com/gruntwork-io/terraform-aws-ci/test/upgrades.TFTargetVersion=$UPGRADE_TEST_TF_TARGET_VERSION'" \
+              --extra-flags "-ldflags '-X github.com/gruntwork-io/module-ci/test/upgrades.BaseRef=$UPGRADE_TEST_BASE_REF -X github.com/gruntwork-io/module-ci/test/upgrades.TFBaseVersion=$UPGRADE_TEST_TF_BASE_VERSION -X github.com/gruntwork-io/module-ci/test/upgrades.TFTargetVersion=$UPGRADE_TEST_TF_TARGET_VERSION'" \
               | (tee /tmp/logs/all.log || true)
           no_output_timeout: 3600s
       - store_results
@@ -103,7 +103,7 @@ workflows:
   version: 2.1
   test:
     jobs:
-      # By default CircleCI runs jobs on all branches but no tags. 
+      # By default CircleCI runs jobs on all branches but no tags.
       # We need a filter to ensure jobs run on all tags starting with v.
       - precommit:
           filters:

--- a/.circleci/set-upgrade-test-vars.sh
+++ b/.circleci/set-upgrade-test-vars.sh
@@ -2,12 +2,12 @@
 # Set some variables that are used by the upgrade test runner (run-go-tests), passing in
 # these variables as overrides with --extra-flags and -ldflags.
 
-DEFAULT_BRANCH="master"
+DEFAULT_BRANCH="main"
 
 # Call gh to get the base ref that we should run our upgrade tests against.
 baseRef=""
 if [[ "$CIRCLE_BRANCH" == "$DEFAULT_BRANCH" ]]; then
-  # On master, the commit to compare to should be the last release tag.
+  # On main, the commit to compare to should be the last release tag.
   baseRef="$(gh release list --exclude-drafts --limit 1 | awk '{print $3}')"
   echo "export UPGRADE_TEST_BASE_REF=$baseRef" >> $BASH_ENV
 else

--- a/test/upgrades/constants.go
+++ b/test/upgrades/constants.go
@@ -1,8 +1,7 @@
 package upgrades
 
 const (
-	repoName          = "terraform-aws-utilities"
-	defaultBranchName = "master"
+	repoName = "terraform-aws-utilities"
 )
 
 // The following lists are to keep track of which of the examples we've added upgrade tests for,


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Downstream updates to handle the default branch change.
<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
(no functional changes)