### PR TITLE
Use origin/HEAD as Base Ref for upgrade testing.

### DIFF
--- a/.circleci/set-upgrade-test-vars.sh
+++ b/.circleci/set-upgrade-test-vars.sh
@@ -2,7 +2,7 @@
 # Set some variables that are used by the upgrade test runner (run-go-tests), passing in
 # these variables as overrides with --extra-flags and -ldflags.
 
-DEFAULT_BRANCH="main"
+DEFAULT_BRANCH="origin/HEAD"
 
 # Call gh to get the base ref that we should run our upgrade tests against.
 baseRef=""


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

We want to stop referencing the default branch's name! Instead we use `origin/HEAD` when we mean the head of the default branch. I've verified in the tests that the correct ref is getting checked out.

```
[] time="2022-07-15T16:39:27Z" level=info msg="Running command: git checkout origin/HEAD"
HEAD is now at d0f7579 Fix upgrade tests to use main as the base branch instead of master (#65)
```

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated upgrade tests to use origin/HEAD as the base ref to compare to.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
