### PR TITLE
chore: pin hashi external provider to 2.2.3

### DIFF
--- a/modules/require-executable/main.tf
+++ b/modules/require-executable/main.tf
@@ -1,6 +1,18 @@
 terraform {
   # This module is now only being tested with Terraform 1.1.x. However, to make upgrading easier, we are setting 1.0.0 as the minimum version.
   required_version = ">= 1.0.0"
+
+  # Updating the Terraform external provider to 2.3.0 caused an undocumented breaking change (as evidenced by
+  # issues like https://github.com/hashicorp/terraform-provider-external/issues/193). The solution is to pin 
+  # the version to a working version for now. 
+  # Special thanks to Lorelei Rupp for reporting and discovering the root cause of this issue!
+  # TODO: Once the issue is fixed. Update the version constraint to the latest non-breaking version.
+  required_providers {
+    external = {
+      source  = "hashicorp/external"
+      version = "= 2.2.3"
+    }
+  }
 }
 
 data "external" "required_executable" {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

<!-- Description of the changes introduced by this PR. -->

Addresses [issue](https://github.com/hashicorp/terraform-provider-external/issues/193) with Hashicorp external provider v2.3.0 reported in our Slack community by Lorelei Rupp. 

This change pins the version to v2.2.3, to prevent unexpected terraform plan failures due to missing missing required key `"required_executables"`

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added version pin to v2.2.3 for Hashicorp external provider

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
