### PR TITLE
Add Terrascan to CI - CORE-1371

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,6 @@ jobs:
             # See https://runterrascan.io/docs/_print/#configuring-the-output-format-for-a-scan for information on terrascan exit codes.
             terrascan scan -d ./modules --output json || (ec=$?; if [[ $ec = 4 ]]; then exit 0; else exit $ec; fi;)
           no_output_timeout: 3600s
-      - store_results
   upgrade_test:
     description: Run upgrades and post the results on the PR.
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
             run-go-tests --path ./test --timeout 2h --packages . | (tee /tmp/logs/all.log || true)
           no_output_timeout: 5400s
       - store_results
-  scan:
+  terrascan:
     description: Run Terrascan
     <<: *terrascan
     steps:
@@ -146,7 +146,7 @@ workflows:
           context:
             - AWS__PHXDEVOPS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci
-      - scan:
+      - terrascan:
           requires:
             - precommit
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ jobs:
             # We only want to fail on violations, so we need to ignore exit code 4
             # See https://runterrascan.io/docs/_print/#configuring-the-output-format-for-a-scan for information on terrascan exit codes.
             terrascan scan -d ./modules --output json || (ec=$?; if [[ $ec = 4 ]]; then exit 0; else exit $ec; fi;)
+          no_output_timeout: 3600s
       - store_results
   upgrade_test:
     description: Run upgrades and post the results on the PR.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,10 @@ defaults: &defaults
   docker:
     - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.21-tf1.5-tg39.1-pck1.8-ci50.7
   <<: *env
+terrascan: &terrascan
+  docker:
+    - image: "tenable/terrascan:1.18.3"
+  <<: *env
 run_precommit: &run_precommit
   # Fail the build if the pre-commit hooks don't pass. Note: if you run $ pre-commit install locally within this repo, these hooks will
   # execute automatically every time before you commit, ensuring the build never fails at this step!
@@ -64,6 +68,14 @@ jobs:
             run-go-tests --path ./test --timeout 2h --packages . | (tee /tmp/logs/all.log || true)
           no_output_timeout: 5400s
       - store_results
+  scan:
+    description: Run Terrascan
+    <<: *terrascan
+    steps:
+      - checkout
+      - run:
+          name: Run terrascan
+          command: terrascan scan -d ./modules --output json || (ec=$?; if [[ $ec = 4 ]]; then exit 0; else exit $ec; fi;)
   upgrade_test:
     description: Run upgrades and post the results on the PR.
     <<: *defaults
@@ -113,6 +125,24 @@ workflows:
             - AWS__PHXDEVOPS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci
       - test:
+          requires:
+            - precommit
+          filters:
+            tags:
+              only: /^v.*/
+          context:
+            - AWS__PHXDEVOPS__circle-ci-test
+            - GITHUB__PAT__gruntwork-ci
+  scan:
+    jobs:
+      - precommit:
+          filters:
+            tags:
+              only: /^v.*/
+          context:
+            - AWS__PHXDEVOPS__circle-ci-test
+            - GITHUB__PAT__gruntwork-ci
+      - scan:
           requires:
             - precommit
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,10 @@ jobs:
       - checkout
       - run:
           name: Run terrascan
-          command: terrascan scan -d ./modules --output json || (ec=$?; if [[ $ec = 4 ]]; then exit 0; else exit $ec; fi;)
+          command: |
+          # We only want to fail on violations, so we need to ignore exit code 4
+          # See https://runterrascan.io/docs/_print/#configuring-the-output-format-for-a-scan for information on terrascan exit codes.
+          terrascan scan -d ./modules --output json || (ec=$?; if [[ $ec = 4 ]]; then exit 0; else exit $ec; fi;)
   upgrade_test:
     description: Run upgrades and post the results on the PR.
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,9 +76,9 @@ jobs:
       - run:
           name: Run terrascan
           command: |
-          # We only want to fail on violations, so we need to ignore exit code 4
-          # See https://runterrascan.io/docs/_print/#configuring-the-output-format-for-a-scan for information on terrascan exit codes.
-          terrascan scan -d ./modules --output json || (ec=$?; if [[ $ec = 4 ]]; then exit 0; else exit $ec; fi;)
+            # We only want to fail on violations, so we need to ignore exit code 4
+            # See https://runterrascan.io/docs/_print/#configuring-the-output-format-for-a-scan for information on terrascan exit codes.
+            terrascan scan -d ./modules --output json || (ec=$?; if [[ $ec = 4 ]]; then exit 0; else exit $ec; fi;)
   upgrade_test:
     description: Run upgrades and post the results on the PR.
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ jobs:
             # We only want to fail on violations, so we need to ignore exit code 4
             # See https://runterrascan.io/docs/_print/#configuring-the-output-format-for-a-scan for information on terrascan exit codes.
             terrascan scan -d ./modules --output json || (ec=$?; if [[ $ec = 4 ]]; then exit 0; else exit $ec; fi;)
+      - store_results
   upgrade_test:
     description: Run upgrades and post the results on the PR.
     <<: *defaults


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Add Terrascan to CI

[CI Output](https://app.circleci.com/pipelines/github/gruntwork-io/terraform-aws-utilities/230/workflows/f18aeb6d-817a-49a3-859c-9e952cf93e3a/jobs/684)

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes

<!-- One-line description of the PR that can be included in the final release notes. -->
Added Terrascan to CI