### PR TITLE
uptick a long ignored version pin of hashicorp/external to latest

### DIFF
--- a/modules/require-executable/main.tf
+++ b/modules/require-executable/main.tf
@@ -1,15 +1,10 @@
 terraform {
   required_version = ">= 1.0.0"
 
-  # Updating the Terraform external provider to 2.3.0 caused an undocumented breaking change (as evidenced by
-  # issues like https://github.com/hashicorp/terraform-provider-external/issues/193). The solution is to pin 
-  # the version to a working version for now. 
-  # Special thanks to Lorelei Rupp for reporting and discovering the root cause of this issue!
-  # TODO: Once the issue is fixed. Update the version constraint to the latest non-breaking version.
   required_providers {
     external = {
       source  = "hashicorp/external"
-      version = "= 2.2.3"
+      version = ">= 2.3.5"
     }
   }
 }


### PR DESCRIPTION

## Description

Upticks ancient version pin of hashicorp/external

<!-- Description of the changes introduced by this PR. -->

## Release Notes

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated modules/require-executable to new hashicorp/external version pin.
