### PR TITLE
chore: bump cloud-nuke to v0.49.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
       - run:
           name: Install cloud-nuke
           command: |
-            curl -fsSL -o /tmp/cloud-nuke "https://github.com/gruntwork-io/cloud-nuke/releases/download/v0.48.0/cloud-nuke_linux_amd64"
+            curl -fsSL -o /tmp/cloud-nuke "https://github.com/gruntwork-io/cloud-nuke/releases/download/v0.49.0/cloud-nuke_linux_amd64"
             chmod +x /tmp/cloud-nuke
             sudo mv /tmp/cloud-nuke /usr/local/bin/cloud-nuke
       - run:


### PR DESCRIPTION
## Summary
- Bump cloud-nuke from v0.48.0 to v0.49.0 for scheduled nuke runs

## Changes
- Updated `.circleci/config.yml` cloud-nuke download URL from `v0.48.0` to `v0.49.0`