### PR TITLE
chore: run cloud-nuke cleanup across all regions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,8 +135,6 @@ jobs:
             cloud-nuke aws \
               --force \
               --log-level info \
-              --region us-east-1 \
-              --region us-east-2 \
               --older-than 1h \
               --include-tag "gw:repo=^https://github.com/gruntwork-io/terraform-aws-utilities$" \
               --output-format json \
@@ -151,7 +149,6 @@ jobs:
           command: |
             WEBHOOK_URL=$(aws secretsmanager get-secret-value \
               --secret-id "cost-anomaly-alerts/slack-webhook-url" \
-              --region us-east-1 \
               --query 'SecretString' --output text)
             curl -X POST "$WEBHOOK_URL" \
               -H 'Content-Type: application/json' \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,7 @@ jobs:
           command: |
             WEBHOOK_URL=$(aws secretsmanager get-secret-value \
               --secret-id "cost-anomaly-alerts/slack-webhook-url" \
+              --region us-east-1 \
               --query 'SecretString' --output text)
             curl -X POST "$WEBHOOK_URL" \
               -H 'Content-Type: application/json' \


### PR DESCRIPTION
Remove `--region` flags so cloud-nuke scans all enabled regions instead of just us-east-1 and us-east-2. Tests can create resources in other regions which were previously missed by per-repo cleanup.