### PR TITLE
fix: harden cloud-nuke cleanup CI and bump to v0.50.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,12 +121,12 @@ jobs:
       - run:
           name: Install AWS CLI
           command: |
-            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscli.zip
+            curl -fsSL --retry 5 --retry-delay 10 --retry-all-errors --retry-connrefused "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscli.zip
             unzip -q /tmp/awscli.zip -d /tmp && sudo /tmp/aws/install
       - run:
           name: Install cloud-nuke
           command: |
-            curl -fsSL -o /tmp/cloud-nuke "https://github.com/gruntwork-io/cloud-nuke/releases/download/v0.49.0/cloud-nuke_linux_amd64"
+            curl -fsSL --retry 5 --retry-delay 10 --retry-all-errors --retry-connrefused -o /tmp/cloud-nuke "https://github.com/gruntwork-io/cloud-nuke/releases/download/v0.50.0/cloud-nuke_linux_amd64"
             chmod +x /tmp/cloud-nuke
             sudo mv /tmp/cloud-nuke /usr/local/bin/cloud-nuke
       - run:
@@ -135,6 +135,7 @@ jobs:
             cloud-nuke aws \
               --force \
               --log-level info \
+              --exclude-region me-central-1 \
               --older-than 1h \
               --include-tag "gw:repo=^https://github.com/gruntwork-io/terraform-aws-utilities$" \
               --output-format json \


### PR DESCRIPTION
## Changes

1. **Bump cloud-nuke v0.49.0 to v0.50.0** (https://github.com/gruntwork-io/cloud-nuke/releases/tag/v0.50.0). v0.50.0 includes:
   - gruntwork-io/cloud-nuke#1130: IPAM custom-allocation fails in multi-region runs (v0.49.0 regression from #992).
   - gruntwork-io/cloud-nuke#1131: ECS cluster delete fails with `ClusterContainsContainerInstancesException` when EC2-launch-type clusters have registered instances.
   - gruntwork-io/cloud-nuke#1132: ENI `currently in use` reclassified as a non-fatal warning.
2. **Retry GitHub downloads** for both `Install cloud-nuke` and `Install AWS CLI` curls (`--retry 5 --retry-delay 10 --retry-all-errors --retry-connrefused`). Addresses ~4 install-step failures per week observed across the fleet.
3. **Exclude `me-central-1`** from the nuke scope. AWS itself does not publish endpoints for Macie or SES in this region (NXDOMAIN and `192.0.2.1` sentinel respectively), and several other services flake intermittently. Every run logs a burst of `ERROR` lines that are non-fatal but noisy and cost ~90s of wall time.

## Test plan

- [ ] Next scheduled run has no me-central-1 ERROR lines
- [ ] No `unable to find pool allocation info` errors
- [ ] Cleanup still succeeds on resources in other regions
