### PR TITLE
Scope cloud-nuke cleanup to repo resource types (v0.51.0)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
       - run:
           name: Install cloud-nuke
           command: |
-            curl -fsSL --retry 5 --retry-delay 10 --retry-all-errors --retry-connrefused -o /tmp/cloud-nuke "https://github.com/gruntwork-io/cloud-nuke/releases/download/v0.50.0/cloud-nuke_linux_amd64"
+            curl -fsSL --retry 5 --retry-delay 10 --retry-all-errors --retry-connrefused -o /tmp/cloud-nuke "https://github.com/gruntwork-io/cloud-nuke/releases/download/v0.51.0/cloud-nuke_linux_amd64"
             chmod +x /tmp/cloud-nuke
             sudo mv /tmp/cloud-nuke /usr/local/bin/cloud-nuke
       - run:
@@ -138,6 +138,11 @@ jobs:
               --exclude-region me-central-1 \
               --older-than 1h \
               --include-tag "gw:repo=^https://github.com/gruntwork-io/terraform-aws-utilities$" \
+              --resource-type ec2 \
+              --resource-type ebs \
+              --resource-type network-interface \
+              --resource-type ec2-keypairs \
+              --resource-type security-group \
               --output-format json \
               --output-file /tmp/cloud-nuke-results.json
           no_output_timeout: 3600s


### PR DESCRIPTION
Scopes the scheduled cloud-nuke cleanup to the resource types this repo's tests create, and bumps the pinned cloud-nuke binary to v0.51.0.

The job currently scans all 119 regional resource types across every enabled region on each run (commonly ~25-30 min) even when nothing has leaked, which is the bulk of its runtime and CircleCI cost. Restricting `--resource-type` to the types this repo actually creates shrinks the per-run scan while keeping the hourly detection cadence unchanged.

Deletion stays tag-gated via `--include-tag gw:repo=...`, so the allowlist only limits what is scanned, never what can be deleted. It cannot touch resources from other repos or shared infrastructure.

The allowlist was derived from this repo's examples and modules, including transitive resources such as ENIs and security groups created by anything deployed into a VPC.

Ref: OSS-3751

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure cleanup tool to v0.51.0
  * Enhanced cleanup process with refined resource type filtering for cloud infrastructure management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->