### PR TITLE
Bump cloud-nuke cleanup to v0.52.0 (parallel scan)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
       - run:
           name: Install cloud-nuke
           command: |
-            curl -fsSL --retry 5 --retry-delay 10 --retry-all-errors --retry-connrefused -o /tmp/cloud-nuke "https://github.com/gruntwork-io/cloud-nuke/releases/download/v0.51.0/cloud-nuke_linux_amd64"
+            curl -fsSL --retry 5 --retry-delay 10 --retry-all-errors --retry-connrefused -o /tmp/cloud-nuke "https://github.com/gruntwork-io/cloud-nuke/releases/download/v0.52.0/cloud-nuke_linux_amd64"
             chmod +x /tmp/cloud-nuke
             sudo mv /tmp/cloud-nuke /usr/local/bin/cloud-nuke
       - run:


### PR DESCRIPTION
Bumps the pinned cloud-nuke binary in the scheduled cleanup job to v0.52.0, which scans and nukes in parallel instead of serially.

On the CircleCI `small` runners these jobs run on, the old binary effectively used 2-way concurrency (GOMAXPROCS resolves to the 2-CPU quota). v0.52.0 defaults `--parallelism` to a fixed 10. Validated on a real `small` runner: the same read-only scan went from 77s to 32s (~2.4x), identical results, no throttling. No flag changes are needed, the new default applies automatically; within-region deletion order is preserved and global resources are deleted last.

Ref: OSS-3751

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cloud-Nuke version in CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->